### PR TITLE
Fix metal and opengl issue

### DIFF
--- a/src/Bliss/CSharp/Geometry/Mesh.cs
+++ b/src/Bliss/CSharp/Geometry/Mesh.cs
@@ -229,7 +229,7 @@ public class Mesh : Disposable {
                     this._modelMatrixBuffer,
                     this._boneBuffer
                 ],
-                TextureLayouts = material.TextureLayouts,
+                TextureLayouts = material.TextureLayouts.ToArray(),
                 ShaderSet = new ShaderSetDescription() {
                     VertexLayouts = [
                         material.Effect.VertexLayout

--- a/src/Bliss/CSharp/Geometry/Mesh.cs
+++ b/src/Bliss/CSharp/Geometry/Mesh.cs
@@ -5,6 +5,7 @@ using Bliss.CSharp.Colors;
 using Bliss.CSharp.Geometry.Bones;
 using Bliss.CSharp.Graphics.Pipelines;
 using Bliss.CSharp.Graphics.Pipelines.Buffers;
+using Bliss.CSharp.Graphics.Pipelines.Textures;
 using Bliss.CSharp.Graphics.VertexTypes;
 using Bliss.CSharp.Materials;
 using Bliss.CSharp.Transformations;
@@ -164,12 +165,12 @@ public class Mesh : Disposable {
             commandList.SetGraphicsResourceSet(1, this._boneBuffer.ResourceSet);
             
             // Set material.
-            for (int i = 0; i < 11; i++) {
-                MaterialMapType mapType = (MaterialMapType) i;
-                ResourceSet? resourceSet = this.Material.GetResourceSet(this.Material.TextureLayouts[i].Layout, mapType);
-
+            foreach (var textureLayout in this.Material.TextureLayouts.Select((value, i) => ( value, i )))
+            {
+                ResourceSet? resourceSet = this.Material.GetResourceSet(textureLayout.value.Layout, this.Material.GetMaterialMapType(textureLayout.value.Name));
+                
                 if (resourceSet != null) {
-                    commandList.SetGraphicsResourceSet((uint) i + 2, resourceSet);
+                    commandList.SetGraphicsResourceSet((uint) textureLayout.i + 2, resourceSet);
                 }
             }
             
@@ -191,12 +192,12 @@ public class Mesh : Disposable {
             commandList.SetGraphicsResourceSet(1, this._boneBuffer.ResourceSet);
             
             // Set material.
-            for (int i = 0; i < 11; i++) {
-                MaterialMapType mapType = (MaterialMapType) i;
-                ResourceSet? resourceSet = this.Material.GetResourceSet(this.Material.TextureLayouts[i].Layout, mapType);
-
+            foreach (var textureLayout in this.Material.TextureLayouts.Select((value, i) => ( value, i )))
+            {
+                ResourceSet? resourceSet = this.Material.GetResourceSet(textureLayout.value.Layout, this.Material.GetMaterialMapType(textureLayout.value.Name));
+                
                 if (resourceSet != null) {
-                    commandList.SetGraphicsResourceSet((uint) i + 2, resourceSet);
+                    commandList.SetGraphicsResourceSet((uint) textureLayout.i + 2, resourceSet);
                 }
             }
             

--- a/src/Bliss/CSharp/Geometry/Model.cs
+++ b/src/Bliss/CSharp/Geometry/Model.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Assimp;
 using Bliss.CSharp.Effects;
 using Bliss.CSharp.Geometry.Conversions;
+using Bliss.CSharp.Graphics.Pipelines.Textures;
 using Bliss.CSharp.Graphics.VertexTypes;
 using Bliss.CSharp.Logging;
 using Bliss.CSharp.Materials;
@@ -97,37 +98,62 @@ public class Model : Disposable {
 
             if (scene.HasMaterials && loadMaterial) {
                 AMaterial aMaterial = scene.Materials[mesh.MaterialIndex];
+
+                if (aMaterial.HasTextureDiffuse)
+                {
+                    material.AddTextureLayout(new SimpleTextureLayout(graphicsDevice, "fAlbedoTexture"));
+                    material.SetMaterialMap(MaterialMapType.Albedo, new MaterialMap() {
+                        Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Diffuse),
+                        Color = new Color((byte) aMaterial.ColorDiffuse.R, (byte) aMaterial.ColorDiffuse.G, (byte) aMaterial.ColorDiffuse.B, (byte) aMaterial.ColorDiffuse.A)
+                    });
+                    material.SetMaterialMapType("fAlbedoTexture", MaterialMapType.Albedo);
+                }
                 
-                material.SetMaterialMap(MaterialMapType.Albedo, new MaterialMap() {
-                    Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Diffuse),
-                    Color = new Color((byte) aMaterial.ColorDiffuse.R, (byte) aMaterial.ColorDiffuse.G, (byte) aMaterial.ColorDiffuse.B, (byte) aMaterial.ColorDiffuse.A)
-                });
+                // material.SetMaterialMap(MaterialMapType.Metalness, new MaterialMap() {
+                //     Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Metalness),
+                //     Color = new Color((byte) aMaterial.ColorSpecular.R, (byte) aMaterial.ColorSpecular.G, (byte) aMaterial.ColorSpecular.B, (byte) aMaterial.ColorSpecular.A)
+                // });
+
+                if (aMaterial.HasTextureNormal)
+                {
+                    material.AddTextureLayout(new SimpleTextureLayout(graphicsDevice, "fNormalTexture"));
+                    material.SetMaterialMap(MaterialMapType.Normal, new MaterialMap() {
+                        Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Normals)
+                    });
+                    material.SetMaterialMapType("fNormalTexture", MaterialMapType.Normal);
+                }
                 
-                material.SetMaterialMap(MaterialMapType.Metalness, new MaterialMap() {
-                    Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Metalness),
-                    Color = new Color((byte) aMaterial.ColorSpecular.R, (byte) aMaterial.ColorSpecular.G, (byte) aMaterial.ColorSpecular.B, (byte) aMaterial.ColorSpecular.A)
-                });
+                // material.SetMaterialMap(MaterialMapType.Roughness, new MaterialMap() {
+                //     Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Roughness)
+                // });
                 
-                material.SetMaterialMap(MaterialMapType.Normal, new MaterialMap() {
-                    Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Normals)
-                });
-                
-                material.SetMaterialMap(MaterialMapType.Roughness, new MaterialMap() {
-                    Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Roughness)
-                });
-                
-                material.SetMaterialMap(MaterialMapType.Occlusion, new MaterialMap() {
-                    Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.AmbientOcclusion)
-                });
-                
-                material.SetMaterialMap(MaterialMapType.Emission, new MaterialMap() {
-                    Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Emissive),
-                    Color = new Color((byte) aMaterial.ColorEmissive.R, (byte) aMaterial.ColorEmissive.G, (byte) aMaterial.ColorEmissive.B, (byte) aMaterial.ColorEmissive.A)
-                });
-                
-                material.SetMaterialMap(MaterialMapType.Height, new MaterialMap() {
-                    Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Height)
-                });
+                if (aMaterial.HasTextureAmbientOcclusion)
+                {
+                    material.AddTextureLayout(new SimpleTextureLayout(graphicsDevice, "fAmbientOcclusionTexture"));
+                    material.SetMaterialMap(MaterialMapType.Occlusion, new MaterialMap() {
+                        Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.AmbientOcclusion)
+                    });
+                    material.SetMaterialMapType("fAmbientOcclusionTexture", MaterialMapType.Occlusion);
+                }
+
+                if (aMaterial.HasTextureEmissive)
+                {
+                    material.AddTextureLayout(new SimpleTextureLayout(graphicsDevice, "fEmissiveTexture"));
+                    material.SetMaterialMap(MaterialMapType.Emission, new MaterialMap() {
+                        Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Emissive),
+                        Color = new Color((byte) aMaterial.ColorEmissive.R, (byte) aMaterial.ColorEmissive.G, (byte) aMaterial.ColorEmissive.B, (byte) aMaterial.ColorEmissive.A)
+                    });
+                    material.SetMaterialMapType("fEmissiveTexture", MaterialMapType.Emission);
+                }
+
+                if (aMaterial.HasTextureHeight)
+                {
+                    material.AddTextureLayout(new SimpleTextureLayout(graphicsDevice, "fHeightTexture"));
+                    material.SetMaterialMap(MaterialMapType.Height, new MaterialMap() {
+                        Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Height)
+                    });
+                    material.SetMaterialMapType("fHeightTexture", MaterialMapType.Height);
+                }
             }
             
             // Setup vertices.

--- a/src/Bliss/CSharp/Geometry/Model.cs
+++ b/src/Bliss/CSharp/Geometry/Model.cs
@@ -108,11 +108,17 @@ public class Model : Disposable {
                     });
                     material.SetMaterialMapType("fAlbedoTexture", MaterialMapType.Albedo);
                 }
-                
-                // material.SetMaterialMap(MaterialMapType.Metalness, new MaterialMap() {
-                //     Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Metalness),
-                //     Color = new Color((byte) aMaterial.ColorSpecular.R, (byte) aMaterial.ColorSpecular.G, (byte) aMaterial.ColorSpecular.B, (byte) aMaterial.ColorSpecular.A)
-                // });
+
+                if (aMaterial.PBR.HasTextureMetalness)
+                {
+                    material.AddTextureLayout(new SimpleTextureLayout(graphicsDevice, "fMetallicTexture"));
+                    material.SetMaterialMap(MaterialMapType.Metalness, new MaterialMap()
+                    {
+                        Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Metalness),
+                        Color = new Color((byte)aMaterial.ColorSpecular.R, (byte)aMaterial.ColorSpecular.G, (byte)aMaterial.ColorSpecular.B, (byte)aMaterial.ColorSpecular.A)
+                    });
+                    material.SetMaterialMapType("fMetallicTexture", MaterialMapType.Metalness);
+                }
 
                 if (aMaterial.HasTextureNormal)
                 {
@@ -122,11 +128,17 @@ public class Model : Disposable {
                     });
                     material.SetMaterialMapType("fNormalTexture", MaterialMapType.Normal);
                 }
-                
-                // material.SetMaterialMap(MaterialMapType.Roughness, new MaterialMap() {
-                //     Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Roughness)
-                // });
-                
+
+                if (aMaterial.PBR.HasTextureRoughness)
+                {
+                    material.AddTextureLayout(new SimpleTextureLayout(graphicsDevice, "fRoughnessTexture"));
+                    material.SetMaterialMap(MaterialMapType.Roughness, new MaterialMap()
+                    {
+                        Texture = LoadMaterialTexture(graphicsDevice, scene, aMaterial, path, TextureType.Roughness)
+                    });
+                    material.SetMaterialMapType("fRoughnessTexture", MaterialMapType.Roughness);
+                }
+
                 if (aMaterial.HasTextureAmbientOcclusion)
                 {
                     material.AddTextureLayout(new SimpleTextureLayout(graphicsDevice, "fAmbientOcclusionTexture"));

--- a/src/Bliss/CSharp/Materials/Material.cs
+++ b/src/Bliss/CSharp/Materials/Material.cs
@@ -44,6 +44,8 @@ public class Material : Disposable {
     /// </summary>
     private Dictionary<(Sampler, ResourceLayout), ResourceSet> _cachedResourceSets;
     
+    private Dictionary<string, MaterialMapType> _mapTypes;
+    
     /// <summary>
     /// Initializes a new instance of the <see cref="Material"/> class, configuring it with the specified
     /// graphics device, shader effect, and optional blend state.
@@ -59,6 +61,7 @@ public class Material : Disposable {
         this.Parameters = new List<float>();
         this._maps = this.SetDefaultMaterialMaps();
         this._cachedResourceSets = new Dictionary<(Sampler, ResourceLayout), ResourceSet>();
+        this._mapTypes = new Dictionary<string, MaterialMapType>();
     }
 
     /// <summary>
@@ -86,6 +89,16 @@ public class Material : Disposable {
         return resourceSet;
     }
 
+    public MaterialMapType GetMaterialMapType(string materialMapName)
+    {
+        return this._mapTypes[materialMapName];
+    }
+
+    public void SetMaterialMapType(string materialMapName, MaterialMapType materialMapType)
+    {
+        this._mapTypes[materialMapName] = materialMapType;
+    }
+
     /// <summary>
     /// Retrieves the material map associated with the specified material map type.
     /// </summary>
@@ -100,7 +113,8 @@ public class Material : Disposable {
     /// </summary>
     /// <param name="mapType">The type of the material map to set.</param>
     /// <param name="map">The material map to assign to the specified type.</param>
-    public void SetMaterialMap(MaterialMapType mapType, MaterialMap map) {
+    public void SetMaterialMap(MaterialMapType mapType, MaterialMap map)
+    {
         this._maps[mapType] = map;
     }
 
@@ -176,39 +190,39 @@ public class Material : Disposable {
     /// <returns>A dictionary where the key is the material map type and the value is the associated default material map.</returns>
     private Dictionary<MaterialMapType, MaterialMap> SetDefaultMaterialMaps() {
         return new Dictionary<MaterialMapType, MaterialMap> {
-            {
-                MaterialMapType.Albedo, new MaterialMap()
-            },
-            {
-                MaterialMapType.Metalness, new MaterialMap()
-            },
-            {
-                MaterialMapType.Normal, new MaterialMap()
-            },
-            {
-                MaterialMapType.Roughness, new MaterialMap()
-            },
-            {
-                MaterialMapType.Occlusion, new MaterialMap()
-            },
-            {
-                MaterialMapType.Emission, new MaterialMap()
-            },
-            {
-                MaterialMapType.Height, new MaterialMap()
-            },
-            {
-                MaterialMapType.Cubemap, new MaterialMap()
-            },
-            {
-                MaterialMapType.Irradiance, new MaterialMap()
-            },
-            {
-                MaterialMapType.Prefilter, new MaterialMap()
-            },
-            {
-                MaterialMapType.Brdf, new MaterialMap()
-            }
+            // {
+            //     MaterialMapType.Albedo, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Metalness, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Normal, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Roughness, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Occlusion, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Emission, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Height, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Cubemap, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Irradiance, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Prefilter, new MaterialMap()
+            // },
+            // {
+            //     MaterialMapType.Brdf, new MaterialMap()
+            // }
         };
     }
 
@@ -219,20 +233,29 @@ public class Material : Disposable {
     /// <returns>An array of <see cref="SimpleTextureLayout"/> objects corresponding to various material textures.</returns>
     private SimpleTextureLayout[] CreateTextureLayout(GraphicsDevice graphicsDevice) {
         return [
-            new SimpleTextureLayout(graphicsDevice, "fAlbedoTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fMetallicTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fNormalTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fRoughnessTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fOcclusionTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fEmissionTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fHeightTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fCubemapTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fIrradianceTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fPrefilterTexture"),
-            new SimpleTextureLayout(graphicsDevice, "fBrdfTexture")
+            // new SimpleTextureLayout(graphicsDevice, "fAlbedoTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fMetallicTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fNormalTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fRoughnessTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fOcclusionTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fEmissionTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fHeightTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fCubemapTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fIrradianceTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fPrefilterTexture"),
+            // new SimpleTextureLayout(graphicsDevice, "fBrdfTexture")
         ];
     }
 
+    public void AddTextureLayout(SimpleTextureLayout layout)
+    {
+        List<SimpleTextureLayout> newLayouts = new List<SimpleTextureLayout>();
+        newLayouts.AddRange(this.TextureLayouts);
+        newLayouts.Add(layout);
+        
+        this.TextureLayouts = newLayouts.ToArray();
+    }
+    
     protected override void Dispose(bool disposing) {
         if (disposing) {
             foreach (SimpleTextureLayout textureLayout in this.TextureLayouts) {

--- a/src/Bliss/CSharp/Materials/Material.cs
+++ b/src/Bliss/CSharp/Materials/Material.cs
@@ -27,7 +27,7 @@ public class Material : Disposable {
     /// <summary>
     /// An array of texture layouts that defines the material's texture configurations.
     /// </summary>
-    public SimpleTextureLayout[] TextureLayouts { get; private set; }
+    public List<SimpleTextureLayout> TextureLayouts { get; private set; }
     
     /// <summary>
     /// A list of floating-point parameters for configuring material properties.
@@ -57,9 +57,9 @@ public class Material : Disposable {
         this.GraphicsDevice = graphicsDevice;
         this.Effect = effect;
         this.BlendState = blendState ?? BlendState.Disabled;
-        this.TextureLayouts = this.CreateTextureLayout(graphicsDevice);
+        this.TextureLayouts = new List<SimpleTextureLayout>();
         this.Parameters = new List<float>();
-        this._maps = this.SetDefaultMaterialMaps();
+        this._maps = new Dictionary<MaterialMapType, MaterialMap> { };
         this._cachedResourceSets = new Dictionary<(Sampler, ResourceLayout), ResourceSet>();
         this._mapTypes = new Dictionary<string, MaterialMapType>();
     }
@@ -89,14 +89,24 @@ public class Material : Disposable {
         return resourceSet;
     }
 
+    /// <summary>
+    /// Get the Materal maps type based on the texture Layout Name
+    /// </summary>
+    /// <param name="materialMapName"></param>
+    /// <returns></returns>
     public MaterialMapType GetMaterialMapType(string materialMapName)
     {
         return this._mapTypes[materialMapName];
     }
 
-    public void SetMaterialMapType(string materialMapName, MaterialMapType materialMapType)
+    /// <summary>
+    /// set the mew dictonary  between the name of texture layout and the material map type
+    /// </summary>
+    /// <param name="textureLayoutName"></param>
+    /// <param name="materialMapType"></param>
+    public void SetMaterialMapType(string textureLayoutName, MaterialMapType materialMapType)
     {
-        this._mapTypes[materialMapName] = materialMapType;
+        this._mapTypes[textureLayoutName] = materialMapType;
     }
 
     /// <summary>
@@ -185,75 +195,12 @@ public class Material : Disposable {
     }
 
     /// <summary>
-    /// Initializes and returns a dictionary containing default material maps for various material map types.
+    /// Add the texture layout to the end of the layouts
     /// </summary>
-    /// <returns>A dictionary where the key is the material map type and the value is the associated default material map.</returns>
-    private Dictionary<MaterialMapType, MaterialMap> SetDefaultMaterialMaps() {
-        return new Dictionary<MaterialMapType, MaterialMap> {
-            // {
-            //     MaterialMapType.Albedo, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Metalness, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Normal, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Roughness, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Occlusion, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Emission, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Height, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Cubemap, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Irradiance, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Prefilter, new MaterialMap()
-            // },
-            // {
-            //     MaterialMapType.Brdf, new MaterialMap()
-            // }
-        };
-    }
-
-    /// <summary>
-    /// Creates an array of texture layouts for the specified graphics device.
-    /// </summary>
-    /// <param name="graphicsDevice">The graphics device used to create the texture layouts.</param>
-    /// <returns>An array of <see cref="SimpleTextureLayout"/> objects corresponding to various material textures.</returns>
-    private SimpleTextureLayout[] CreateTextureLayout(GraphicsDevice graphicsDevice) {
-        return [
-            // new SimpleTextureLayout(graphicsDevice, "fAlbedoTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fMetallicTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fNormalTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fRoughnessTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fOcclusionTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fEmissionTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fHeightTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fCubemapTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fIrradianceTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fPrefilterTexture"),
-            // new SimpleTextureLayout(graphicsDevice, "fBrdfTexture")
-        ];
-    }
-
+    /// <param name="layout"></param>
     public void AddTextureLayout(SimpleTextureLayout layout)
     {
-        List<SimpleTextureLayout> newLayouts = new List<SimpleTextureLayout>();
-        newLayouts.AddRange(this.TextureLayouts);
-        newLayouts.Add(layout);
-        
-        this.TextureLayouts = newLayouts.ToArray();
+        this.TextureLayouts.Add(layout);
     }
     
     protected override void Dispose(bool disposing) {


### PR DESCRIPTION
- Fixes Metal and OpenGL Rendering on Mac
- Fixes OpenGL Rendering on Windows.
- Check for textures before adding them to the SetMaterialMap
- Remove SetDefaultMaterialMaps and CreateTextureLayout as they are dynamic based on the texture now