### PR TITLE
Fix x11, and fix an unaligned SimpleBuffer allocation on Vulkan

### DIFF
--- a/src/Bliss/CSharp/Geometry/Mesh.cs
+++ b/src/Bliss/CSharp/Geometry/Mesh.cs
@@ -159,7 +159,7 @@ public class Mesh : Disposable {
         this._colorBuffer.UpdateBufferImmediate();
         
         // Create value buffer.
-        this._valueBuffer = new SimpleBuffer<float>(graphicsDevice, 7, SimpleBufferType.Uniform, ShaderStages.Fragment);
+        this._valueBuffer = new SimpleBuffer<float>(graphicsDevice, 8, SimpleBufferType.Uniform, ShaderStages.Fragment);
 
         // Create pipeline description.
         this._pipelineDescription = this.CreatePipelineDescription();

--- a/src/Bliss/CSharp/Windowing/Sdl3Window.cs
+++ b/src/Bliss/CSharp/Windowing/Sdl3Window.cs
@@ -699,8 +699,8 @@ public class Sdl3Window : Disposable, IWindow {
         else if (OperatingSystem.IsLinux()) {
             if (SDL3.SDL_strcmp(SDL3.SDL_GetCurrentVideoDriver(), "x11") == 0) {
                 nint display = SDL3.SDL_GetPointerProperty(SDL3.SDL_GetWindowProperties((SDL_Window*) this.Handle), SDL3.SDL_PROP_WINDOW_X11_DISPLAY_POINTER, nint.Zero);
-                nint surface = SDL3.SDL_GetPointerProperty(SDL3.SDL_GetWindowProperties((SDL_Window*) this.Handle), SDL3.SDL_PROP_WINDOW_X11_WINDOW_NUMBER, 0);
-                return SwapchainSource.CreateXlib(display, surface);
+                long surface = SDL3.SDL_GetNumberProperty(SDL3.SDL_GetWindowProperties((SDL_Window*) this.Handle), SDL3.SDL_PROP_WINDOW_X11_WINDOW_NUMBER, 0);
+                return SwapchainSource.CreateXlib(display, (nint) surface);
             }
             else if (SDL3.SDL_strcmp(SDL3.SDL_GetCurrentVideoDriver(), "wayland") == 0) {
                 nint display = SDL3.SDL_GetPointerProperty(SDL3.SDL_GetWindowProperties((SDL_Window*) this.Handle), SDL3.SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER, nint.Zero);


### PR DESCRIPTION
SDL_GetPointerProperty will return 0 on properties that are not a pointer, SDL_PROP_WINDOW_X11_WINDOW_NUMBER is a number not a pointer. This results in the window identifier being zero, and subsequently a segfault on x11 due to the window number being zero. This patch correctly calls SDL_GetNumberProperty which yields the correct x11 window number.

After fixing that, Vulkan enters an invalid allocation state due to SimpleBuffer being not aligned to 16 bytes. Adding a single float (`8 * 4 = 32 % 16 = 0`) resolves this.

N.B. The segfault would've been prevented if `VulkanUtil.CheckResult` (in ppy.Veldrid) did not have `Conditional("DEBUG")`, unsure if I should make an issue request on ppy/Veldrid to remove that conditional or what adverse effects it as.