### PR TITLE
Tangent Space Fix for Mirrored Meshes

### DIFF
--- a/src/Bliss.Test/Game.cs
+++ b/src/Bliss.Test/Game.cs
@@ -55,7 +55,7 @@ public class Game : Disposable {
     private Cam3D _cam3D;
     private Model _playerModel;
     private Model _planeModel;
-
+    
     private Texture2D _customMeshTexture;
     private Mesh _customPoly;
     private Mesh _customCube;
@@ -174,8 +174,9 @@ public class Game : Disposable {
         
         float aspectRatio = (float) this.MainWindow.GetWidth() / (float) this.MainWindow.GetHeight();
         this._cam3D = new Cam3D(new Vector3(0, 3, -3), new Vector3(0, 1.5F, 0), aspectRatio);
-        this._playerModel = Model.Load(this.GraphicsDevice, "content/player.glb");
-        this._planeModel = Model.Load(this.GraphicsDevice, "content/plane.glb");
+        this._playerModel = Model.Load(this.GraphicsDevice ,"content/player.glb", false);
+        this._planeModel = Model.Load(this.GraphicsDevice,"content/test_flippeduvs.glb", false);
+        
         
         this._customMeshTexture = new Texture2D(this.GraphicsDevice, "content/cube.png");
         
@@ -317,8 +318,12 @@ public class Game : Disposable {
         this._customKnot.Draw(commandList, new Transform() { Translation = new Vector3(25, 0, 0)}, this.FullScreenTexture.Framebuffer.OutputDescription);
         this._customHeighmap.Draw(commandList, new Transform() { Translation = new Vector3(27, 0, 0)}, this.FullScreenTexture.Framebuffer.OutputDescription);
 
-        if (this._cam3D.GetFrustum().ContainsBox(this._planeModel.BoundingBox)) {
-            this._planeModel.Draw(commandList, new Transform(), this.FullScreenTexture.Framebuffer.OutputDescription);
+        if (this._cam3D.GetFrustum().ContainsBox(this._planeModel.BoundingBox))
+        {
+            Transform transform = new Transform();
+            transform.Translation = new Vector3(2, 0, 2);
+            transform.Scale = new Vector3(4, 4, 4);
+            this._planeModel.Draw(commandList, transform, this.FullScreenTexture.Framebuffer.OutputDescription);
         }
         
         if (Input.IsKeyPressed(KeyboardKey.G)) {

--- a/src/Bliss/CSharp/Geometry/Mesh.cs
+++ b/src/Bliss/CSharp/Geometry/Mesh.cs
@@ -1101,8 +1101,13 @@ public class Mesh : Disposable {
             Vertex3D vertex = this.Vertices[i];
             Vector3 n = vertex.Normal;
             Vector3 t = tan1[i];
+            Vector3 b = tan2[i];
 
-            Vector3 tangent = Vector3.Normalize(t - n * Vector3.Dot(n, t));
+            float sign = Vector3.Dot(Vector3.Cross(n, t), b) > 0.0f ? 1.0f : -1.0f;
+            
+            
+
+            Vector4 tangent = new Vector4(Vector3.Normalize(t - n * Vector3.Dot(n, t)), sign);
             this.Vertices[i].Tangent = tangent;
         }
     }

--- a/src/Bliss/CSharp/Geometry/Model.cs
+++ b/src/Bliss/CSharp/Geometry/Model.cs
@@ -261,9 +261,12 @@ public class Model : Disposable {
                 
                 // Set Normal.
                 vertices[j].Normal = mesh.HasNormals ? mesh.Normals[j] : Vector3.Zero;
+                
+                float tangentSign = Vector3.Dot(Vector3.Cross(mesh.Normals[j], mesh.Tangents[j]), mesh.BiTangents[j]) > 0.0f ? 1.0f : -1.0f;
 
+                
                 // Set Tangent.
-                vertices[j].Tangent = mesh.HasTangentBasis ? mesh.Tangents[j] : Vector3.Zero;
+                vertices[j].Tangent = mesh.HasTangentBasis ? new Vector4(mesh.Tangents[j], tangentSign) : Vector4.Zero;
                 
                 // Set Color.
                 vertices[j].Color = material.GetMapColor(MaterialMapType.Albedo.GetName())?.ToRgbaFloatVec4() ?? Vector4.Zero;

--- a/src/Bliss/CSharp/Graphics/VertexTypes/Vertex3D.cs
+++ b/src/Bliss/CSharp/Graphics/VertexTypes/Vertex3D.cs
@@ -11,14 +11,14 @@ public struct Vertex3D {
     /// <summary>
     /// Represents the layout description for the <see cref="Vertex3D"/> structure.
     /// </summary>
-    public static VertexLayoutDescription VertexLayout = new VertexLayoutDescription(
+    public static VertexLayoutDescription VertexLayout = new VertexLayoutDescription((3+4+4+2+2+3+4+4)*sizeof(float),
         new VertexElementDescription("vPosition", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float3),
         new VertexElementDescription("vBoneWeights", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float4),
         new VertexElementDescription("vBoneIndices", VertexElementSemantic.TextureCoordinate, VertexElementFormat.UInt4),
         new VertexElementDescription("vTexCoords", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float2),
         new VertexElementDescription("vTexCoords2", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float2),
         new VertexElementDescription("vNormal", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float3),
-        new VertexElementDescription("vTangent", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float3),
+        new VertexElementDescription("vTangent", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float4),
         new VertexElementDescription("vColor", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float4)
     );
     
@@ -55,7 +55,7 @@ public struct Vertex3D {
     /// <summary>
     /// The tangent vector of the vertex, used for normal mapping.
     /// </summary>
-    public Vector3 Tangent;
+    public Vector4 Tangent;
 
     /// <summary>
     /// The color of the vertex.
@@ -71,9 +71,9 @@ public struct Vertex3D {
     /// <param name="texCoords">The primary texture coordinates of the vertex.</param>
     /// <param name="texCoords2">The secondary texture coordinates of the vertex.</param>
     /// <param name="normal">The normal vector at the vertex, used for lighting calculations.</param>
-    /// <param name="tangent">The tangent vector at the vertex, used for normal mapping.</param>
+    /// <param name="tangent">The tangent vector at the vertex, used for normal mapping. Also includes the sign for bitangent.</param>
     /// <param name="color">The color of the vertex, stored as an RGBA float vector.</param>
-    public Vertex3D(Vector3 position, Vector4 boneWeights, UInt4 boneIndices, Vector2 texCoords, Vector2 texCoords2, Vector3 normal, Vector3 tangent, Vector4 color) {
+    public Vertex3D(Vector3 position, Vector4 boneWeights, UInt4 boneIndices, Vector2 texCoords, Vector2 texCoords2, Vector3 normal, Vector4 tangent, Vector4 color) {
         this.Position = position;
         this.BoneWeights = boneWeights;
         this.BoneIndices = boneIndices;

--- a/src/Bliss/content/shaders/default_model.frag
+++ b/src/Bliss/content/shaders/default_model.frag
@@ -16,7 +16,7 @@ layout (set = 4, binding = 1) uniform sampler fAlbedoSampler;
 layout (location = 0) in vec2 fTexCoords;
 layout (location = 1) in vec2 fTexCoords2;
 layout (location = 2) in vec3 fNormal;
-layout (location = 3) in vec3 fTangent;
+layout (location = 3) in vec4 fTangent;
 layout (location = 4) in vec4 fColor;
 
 layout (location = 0) out vec4 fFragColor;
@@ -27,6 +27,12 @@ void main() {
     if (texelColor.a <= 0.0F) {
         discard;
     }
+    
+    mat3 TBN = mat3(fTangent.xyz, normalize(cross(fTangent.xyz,fNormal) * fTangent.w), fNormal);
 
-    fFragColor = texelColor * uColors[0];
+    vec3 wNorm = vec3(TBN * normalize(vec3(0,1,1)));
+    
+    float test = dot(wNorm, normalize(vec3(0.5, -1, 0.2f)));
+    
+    fFragColor = vec4(test * vec3(1,0.5,0.5), 1.0f);//texelColor * uColors[0];
 }

--- a/src/Bliss/content/shaders/default_model.vert
+++ b/src/Bliss/content/shaders/default_model.vert
@@ -16,13 +16,13 @@ layout (location = 2) in uvec4 vBoneIndices;
 layout (location = 3) in vec2 vTexCoords;
 layout (location = 4) in vec2 vTexCoords2;
 layout (location = 5) in vec3 vNormal;
-layout (location = 6) in vec3 vTangent;
+layout (location = 6) in vec4 vTangent;
 layout (location = 7) in vec4 vColor;
 
 layout (location = 0) out vec2 fTexCoords;
 layout (location = 1) out vec2 fTexCoords2;
 layout (location = 2) out vec3 fNormal;
-layout (location = 3) out vec3 fTangent;
+layout (location = 3) out vec4 fTangent;
 layout (location = 4) out vec4 fColor;
 
 mat4x4 getBoneTransformation() {


### PR DESCRIPTION
This pull request fixes the lack of signed bitangent when deriving tangent frame from vertex normal and tangent vectors.

This fixes lighting being inverted on mirrored parts of a model when using normal mapping.